### PR TITLE
Entry mapper improvements + README example improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import (
 )
 
 func TrivialExample() {
-	stream := FromCollection([]interface{}{1,2,3,4})
+    stream := streams.FromCollection([]interface{}{1,2,3,4})
 	someSum := stream.
 		Filter(DivisibleByTwo).
 		Map(TimesFive).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ This example builds a stream from a collection of ints, filters out the ints not
 then multiplies them each 5 five, and sums the elements together. The example is designed to be compact
 and readable so you can quickly understand what this library does.
 ``` Golang
+import (
+	"log"
+	"github.com/Luke-Sikina/streams"
+)
+
 func TrivialExample() {
 	stream := FromCollection([]interface{}{1,2,3,4})
 	someSum := stream.
@@ -81,34 +86,53 @@ This example reads a stream of numbers from a file, filters out the positive eve
 to a second file. There's a lot of boilerplate opening files and setting up bufio objects, so if you're looking
 for the meat of the example, start at `stream := streams.FromScanner(scanner, 1023)`.
 ``` Golang
-// open the input and output files
-input, err := os.Open("input.txt")
-defer closeFileLogErr(input)
-if err != nil {
-    log.Fatalf("Error opening file: %v", err)
+import (
+	"bufio"
+	"log"
+	"os"
+
+	"github.com/Luke-Sikina/streams"
+	"github.com/Luke-Sikina/streams/consumers"
+	"github.com/Luke-Sikina/streams/mappers"
+)
+
+func main() {
+	// open the input and output files
+	input, err := os.Open("input.txt")
+	defer closeFileLogErr(input)
+	if err != nil {
+		log.Fatalf("Error opening file: %v", err)
+	}
+
+	output, err := os.Create("output.txt")
+	defer closeFileLogErr(output)
+	if err != nil {
+		log.Fatalf("Error opening file: %v", err)
+	}
+
+	// set up the scanner and writers
+	scanner := bufio.NewScanner(input)
+	stream := streams.FromScanner(scanner, 1023)
+	writer := bufio.NewWriter(output)
+
+	// run the stream logic
+	stream.
+		Map(mappers.StringToIntMapper).
+		Filter(func(e interface{}) bool {return e.(int) % 2 == 1}).
+		Map(mappers.IntToStringMapper).
+		ForEach(consumers.ConsumeWithDelimitedWriter(writer, "\n"))
+
+	// make sure to flush the writer so you actually get output
+	err = writer.Flush()
+	if err != nil {
+		log.Fatalf("Error flushing buffer: %v", err)
+	}
 }
 
-output, err := os.Create("output.txt")
-defer closeFileLogErr(output)
-if err != nil {
-    log.Fatalf("Error opening file: %v", err)
-}
-
-// set up the scanner and writer
-scanner := bufio.NewScanner(input)
-writer := bufio.NewWriter(output)
-
-// actually use this library to process the data
-stream := streams.FromScanner(scanner, 1023)
-stream.
-    Map(mappers.StringToIntMapper).
-    Filter(func(e interface{}) bool {return e.(int) % 2 == 1}).
-    Map(mappers.IntToStringMapper).
-    ForEach(consumers.ConsumeWithDelimitedWriter(writer, "\n"))
-
-// make sure to flush the writer so you actually get output.
-err = writer.Flush()
-if err != nil {
-    log.Fatalf("Error flushing buffer: %v", err)
+func closeFileLogErr(f *os.File) {
+	err := f.Close()
+	if err != nil {
+		log.Printf("Error closing file: %v", err)
+	}
 }
 ```

--- a/mappers/mappers.go
+++ b/mappers/mappers.go
@@ -46,21 +46,15 @@ func StringToFloatMapper(floatSize int) streams.Mapper {
 	}
 }
 
-// Gets the key from an element
-type KeyGetter func(element interface{}) interface{}
+// Gets the key and value from an element
+type EntryCreator func(element interface{}) (interface{}, interface{})
 
-// Gets the value from an element
-type ValueGetter KeyGetter
-
-// KeyValueMapper takes two functions: a KeyGetter and a ValueGetter.
-// It uses these functions to create a collectors.Entry, which it then returns.
-// The function can be used to create a stream of collectors.Entry for
-// collectors.GroupByCollector and collectors.MapCollector
-func KeyValueMapper(keyGetter KeyGetter, valueGetter ValueGetter) streams.Mapper {
+// KeyValueMapper takes a EntryCreator function. It uses this function to create
+// a collectors.Entry, which it then returns. The function can be used to create
+// a stream of collectors.Entry for collectors.GroupByCollector and collectors.MapCollector
+func KeyValueMapper(toEntry EntryCreator) streams.Mapper {
 	return func(element interface{}) interface{} {
-		return collectors.Entry{
-			Key:   keyGetter(element),
-			Value: valueGetter(element),
-		}
+		key, value := toEntry(element)
+		return collectors.Entry{Key: key, Value: value}
 	}
 }

--- a/mappers/mappers_test.go
+++ b/mappers/mappers_test.go
@@ -126,14 +126,9 @@ type KeyValueMapperCase struct {
 	Expected []interface{}
 }
 
-func GetKey(element interface{}) interface{} {
+func GetEntry(element interface{}) (interface{}, interface{}) {
 	split := strings.Split(element.(string), ":")
-	return split[0]
-}
-
-func GetValue(element interface{}) interface{} {
-	split := strings.Split(element.(string), ":")
-	return split[1]
+	return split[0], split[1]
 }
 
 func TestKeyValueMapper(t *testing.T) {
@@ -153,7 +148,7 @@ func TestKeyValueMapper(t *testing.T) {
 	for _, caze := range cases {
 		stream := streams.FromCollection(caze.Start)
 		actual := stream.
-			Map(KeyValueMapper(GetKey, GetValue)).
+			Map(KeyValueMapper(GetEntry)).
 			Collect(collectors.NewSliceCollector())
 
 		assert.Equal(t, caze.Expected, actual)


### PR DESCRIPTION
The function that maps interface{} to Entry is better, but the improvements made me realize it's mostly useless. Keeping for now. The lesson learned? Don't 1.0 something 3 days in.

The README examples lacked imports, which was bad. Now they have imports. Hopefully, that makes the code more approachable.