### PR TITLE
Coverage codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.8.x
   - tip
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: go
-sudo: false
+
 go:
+  - 1.8.x
   - tip
+
 before_install:
-  - go get github.com/mattn/goveralls
+  - go get -t -v ./...
+
 script:
-  - $GOPATH/bin/goveralls -service=travis-ci
+  - go test -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - go get -t -v ./...
 
 script:
-  - go test -coverprofile=coverage.txt -covermode=atomic
+  - go test ./... -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/Luke-Sikina/streams.svg?branch=master)](https://travis-ci.org/Luke-Sikina/streams)
 [![GoDoc](https://godoc.org/github.com/Luke-Sikina/streams?status.svg)](https://godoc.org/github.com/Luke-Sikina/streams)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Luke-Sikina/streams)](https://goreportcard.com/report/github.com/Luke-Sikina/streams)
-[![Coverage Status](https://coveralls.io/repos/github/Luke-Sikina/streams/badge.svg?branch=coverage)](https://coveralls.io/github/Luke-Sikina/streams?branch=coverage)
+[![codecov](https://codecov.io/gh/Luke-Sikina/streams/branch/master/graph/badge.svg)](https://codecov.io/gh/Luke-Sikina/streams)
 
 Functions for creating and using Streams. Good for performing map / filter / reduce
 operations on datasets you can't keep entirely in memory.


### PR DESCRIPTION
Switch to codecov.

I was having trouble getting coverage to run for all tests with coveralls. The codecov command looked a lot more like the normal test command, so it was easier to change to make sure it ran on all files. This should also make it easier to test for race conditions in the future.